### PR TITLE
Minor fixes to compile code in CMSSW 73

### DIFF
--- a/AnalysisTools/src/ConsistentVertexesCalculator.cc
+++ b/AnalysisTools/src/ConsistentVertexesCalculator.cc
@@ -93,8 +93,8 @@ bool ConsistentVertexesCalculator::Calculate( const pat::MultiMuon *&mm_0, const
     // Extract
     for (unsigned int i = 0; i < 3; ++i){
       for (unsigned int j = 0; j < 3; ++j){
-        mm_0_covMatrix[i][j] = mm_0->vertexCovariance(i,j);
-        mm_1_covMatrix[i][j] = mm_1->vertexCovariance(i,j);
+        mm_0_covMatrix[i][j] = mm_0->my_vertexCovariance(i,j);
+        mm_1_covMatrix[i][j] = mm_1->my_vertexCovariance(i,j);
       }
     }
     

--- a/DataFormats/interface/MultiMuon.h
+++ b/DataFormats/interface/MultiMuon.h
@@ -32,12 +32,7 @@
 #include "TMath.h"
 #include "TTree.h"
 
-#ifdef MULTIMUONCANDIDATE_FOR_FWLITE
-typedef int TransientTrackBuilder;
-#endif
-#ifndef MULTIMUONCANDIDATE_FOR_FWLITE
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#endif
+class TransientTrackBuilder;
 
 // Define typedefs for convenience
 namespace pat {

--- a/DataFormats/interface/MultiMuon.h
+++ b/DataFormats/interface/MultiMuon.h
@@ -184,8 +184,8 @@ namespace pat {
     double          vertexNdof()                    const { checkVertex();  return m_ndof; }
     double          vertexNormalizedChi2()          const { checkVertex();  return (m_ndof > 0. ? m_chi2/m_ndof : 0.); }
     double          vertexProb()                    const { checkVertex();  return (m_ndof > 0. ? TMath::Prob(m_chi2, m_ndof) : 0.); }
-    CovarianceMatrix vertexCovariance()              const { checkVertex();  return m_covarianceMatrix; }
-    double          vertexCovariance(int i, int j) const { checkVertex();  return m_covarianceMatrix.At(i, j); }
+    CovarianceMatrix my_vertexCovariance()              const { checkVertex();  return m_covarianceMatrix; }
+    double          my_vertexCovariance(int i, int j) const { checkVertex();  return m_covarianceMatrix.At(i, j); }
     
     /// return position/momentum of each muon closest to vertex
     GlobalPoint      vertexPCA(int i)                 const { checkVertex();  return m_vertexPCA[i]; }

--- a/DataFormats/src/MultiMuon.cc
+++ b/DataFormats/src/MultiMuon.cc
@@ -7,8 +7,11 @@
 #include "MuJetAnalysis/DataFormats/interface/MultiMuon.h"
 
 #ifndef MULTIMUONCANDIDATE_FOR_FWLITE
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#else
+class TransientTrackBuilder {};
 #endif // MULTIMUONCANDIDATE_FOR_FWLITE
 
 /// default constructor

--- a/MuJetProducer/src/MuJetProducer.cc
+++ b/MuJetProducer/src/MuJetProducer.cc
@@ -382,7 +382,7 @@ void MuJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCollection> primaryVertices;
   iEvent.getByLabel("offlinePrimaryVertices", primaryVertices);
 
-  const reco::Vertex* vtx = &((*primaryVertices)[0]);
+  //  const reco::Vertex* vtx = &((*primaryVertices)[0]);
 
   std::map<const pat::Muon*,bool> used;
   for (pat::MuonCollection::const_iterator one = muons->begin();  one != muons->end();  ++one) {


### PR DESCRIPTION
CMSSW experts recommended to drop vertexCovariance(int i, int j) and use LeafCandidate::vertexCovariance() instead. For the time being, I changed the name to my_vertexCovariance(int i, int j). reco::Vertex* vtx in MuJetProducer is not used and therefore commented out. 