### PR TITLE
MiniAOD fix #2

### DIFF
--- a/CutFlowAnalyzer/plugins/CutFlowAnalyzer_MiniAOD.cc
+++ b/CutFlowAnalyzer/plugins/CutFlowAnalyzer_MiniAOD.cc
@@ -1821,10 +1821,12 @@ CutFlowAnalyzer_MiniAOD::analyze(const edm::Event& iEvent, const edm::EventSetup
   for (int itrig = 0; itrig != ntrigs; ++itrig) {
     TString trigName = triggerNames.triggerName(itrig);
     std::string trigNameStr(trigName.Data());
-    if(std::find(signalHltPaths_.begin(), signalHltPaths_.end(), trigNameStr) != signalHltPaths_.end()) {
-      b_hltPaths.push_back(trigNameStr);
-      if ( m_debug > 10 ) std::cout << trigNameStr << " is present in edmTriggerResults!" << std::endl;
-      b_isDiMuonHLTFired = true;
+    if(trRes->accept(itrig)){
+	    b_hltPaths.push_back(trigNameStr);
+	    if(std::find(signalHltPaths_.begin(), signalHltPaths_.end(), trigNameStr) != signalHltPaths_.end()) {
+		    if ( m_debug > 10 ) std::cout << trigNameStr << " is present in edmTriggerResults!" << std::endl;
+		    b_isDiMuonHLTFired = true;
+	    }
     }
   }
   


### PR DESCRIPTION
Similar to AOD, before push back HLT paths, check if the event passed the trigger bit "itrig" in the HLT menu, otherwise it will push the whole HLT menu.